### PR TITLE
feat(api): version-gated app auth (zero-downtime activation)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,10 @@ UPSTASH_REDIS_REST_TOKEN=your_upstash_rest_token_here
 # 자세한 로드맵: docs/ENDPOINT_AUTH_PLAN.md
 APP_REQUEST_SECRET=your_shared_app_request_secret
 VITE_APP_REQUEST_SECRET=your_shared_app_request_secret
+# 버전 게이트(마이그레이션): 이 버전 미만(또는 x-app-version 미상)인 구버전 앱은 토큰 없이
+# 통과시키고, 이 버전 이상만 토큰을 강제한다. = "토큰을 싣기 시작한 첫 릴리스 버전"으로 설정.
+# 미설정이면 (시크릿이 있을 때) 모든 요청에 토큰 강제(strict). 구버전 출시 앱이 남아 있으면 깨짐.
+APP_AUTH_MIN_VERSION=
 
 # Cost circuit-breaker (Phase 1.5) — 엔드포인트별 전역 일일 호출 상한(서버 전용).
 # 미설정/0 이면 비활성. IP 회전 우회까지 Vision/Kakao 최악의 청구액을 상한으로 묶음.

--- a/api/lib/app-auth.js
+++ b/api/lib/app-auth.js
@@ -12,6 +12,12 @@
  *     박힌 토큰은 추출이 훨씬 어려워 네이티브 경로엔 실효가 있다.
  *   - APP_REQUEST_SECRET 미설정 시: 통과(no-op) — 기존 배포 무중단. 단 1회 경고 로그.
  *
+ * 버전 게이트(마이그레이션): APP_AUTH_MIN_VERSION 설정 시 그 미만 버전(또는 x-app-version
+ *   미상=토큰 지원 이전 출시 앱)은 grace 통과, 그 이상만 토큰 강제. 출시된 구버전 앱을 깨지
+ *   않고 신버전부터 인증을 즉시 켤 수 있다. x-app-version은 위조 가능하므로 보안 경계가 아니라
+ *   마이그레이션 장치이며, grace 구간 남용은 rate-limit/cost-guard로 묶인다. 구버전 소멸 후
+ *   APP_AUTH_MIN_VERSION 제거 시 모든 요청에 토큰 강제(strict).
+ *
  * Phase 2 (계획): 기기 검증(Apple App Attest / Google Play Integrity)을 이 함수에
  *   드롭인. docs/ENDPOINT_AUTH_PLAN.md 참조.
  */
@@ -24,6 +30,18 @@ function safeEqual(a, b) {
   const bb = Buffer.from(String(b));
   if (ba.length !== bb.length) return false;
   return crypto.timingSafeEqual(ba, bb);
+}
+
+// '1.2.0' vs '1.0.4' 비교(숫자 파트만). a<b → -1, a==b → 0, a>b → 1.
+function compareVersions(a, b) {
+  const pa = String(a).split('.').map((n) => parseInt(n, 10) || 0);
+  const pb = String(b).split('.').map((n) => parseInt(n, 10) || 0);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (pa[i] || 0) - (pb[i] || 0);
+    if (diff !== 0) return diff < 0 ? -1 : 1;
+  }
+  return 0;
 }
 
 let warnedMissingSecret = false;
@@ -40,6 +58,18 @@ export function verifyAppRequest(req) {
       warnedMissingSecret = true;
     }
     return { ok: true, reason: 'disabled' };
+  }
+
+  // 버전 게이트(마이그레이션): APP_AUTH_MIN_VERSION 미만 또는 버전 미상(토큰 지원 이전
+  // 출시 앱)은 grace 통과 → 이미 출시된 구버전 앱(예: iOS 1.0.4)을 깨지 않고 신버전부터
+  // 인증을 켤 수 있다. ⚠️ x-app-version은 위조 가능 → 보안 경계가 아니라 마이그레이션 장치.
+  // grace 구간 남용은 rate-limit + cost-guard로 묶이며, 구버전 소멸 후 이 env를 제거하면 strict.
+  const minVersion = process.env.APP_AUTH_MIN_VERSION;
+  if (minVersion) {
+    const clientVersion = req.headers['x-app-version'];
+    if (!clientVersion || compareVersions(clientVersion, minVersion) < 0) {
+      return { ok: true, reason: 'grace-legacy-version' };
+    }
   }
 
   const token = req.headers['x-app-token'];

--- a/docs/ENDPOINT_AUTH_PLAN.md
+++ b/docs/ENDPOINT_AUTH_PLAN.md
@@ -36,6 +36,18 @@
 - **활성화**: 서버 env `OCR_DAILY_MAX` / `IDENTIFY_DAILY_MAX` / `KAKAO_DAILY_MAX` 에 상한 설정.
   미설정/0 이면 no-op(기본 비활성). 일일 정상 사용량 + 여유를 보고 값 설정 권장.
 
+## 버전 게이트 — 무중단 활성화 ✅ (구현됨)
+- `verifyAppRequest`가 `APP_AUTH_MIN_VERSION` 을 읽어, 그 미만(또는 `x-app-version` 미상)인
+  구버전 앱은 grace 통과시키고 그 이상만 토큰 강제. 클라이언트는 `x-app-version`(=빌드 버전) 전송.
+- **이미 출시된 앱(iOS 1.0.4 등)을 깨지 않고** 신버전부터 인증을 즉시 켤 수 있다.
+- ⚠️ `x-app-version` 은 위조 가능 → 보안 경계가 아니라 **마이그레이션 장치**. grace 구간 남용은
+  rate-limit(fail-closed) + cost-guard(전역 일일 상한)로 묶인다.
+- **활성화 절차(안전)**:
+  1. 토큰을 싣는 릴리스 버전 결정(예: 1.2.0). 그 버전으로 웹 재배포 + 네이티브 신규 출시.
+  2. Vercel env: `APP_REQUEST_SECRET`, `VITE_APP_REQUEST_SECRET`(동일값), `APP_AUTH_MIN_VERSION=1.2.0`.
+  3. 이 시점부터 1.2.0+ 요청은 인증 강제, 구버전(1.0.4 등)은 grace 통과(무중단).
+  4. 구버전 사용량이 충분히 소멸하면 `APP_AUTH_MIN_VERSION` 제거 → 전체 strict.
+
 ## Phase 2 — 기기 검증(진짜 인증)
 - **iOS**: Apple App Attest (DeviceCheck) — 앱이 정품 기기의 정품 앱임을 암호학적으로 증명.
 - **Android**: Google Play Integrity API.

--- a/src/lib/api-client.js
+++ b/src/lib/api-client.js
@@ -3,6 +3,8 @@ import { joinUrl } from './runtime-config';
 
 // 앱 요청 인증 토큰(있으면 모든 API 호출에 첨부). 서버는 api/lib/app-auth.js에서 검증.
 const APP_REQUEST_TOKEN = import.meta.env.VITE_APP_REQUEST_SECRET || '';
+// 앱 버전 — 서버의 버전 게이트(APP_AUTH_MIN_VERSION)가 구/신 클라이언트를 구분하는 데 사용.
+const APP_VERSION = CONFIG.BUILD?.VERSION || CONFIG.APP?.VERSION || '';
 
 export function buildApiUrl(path) {
   return joinUrl(CONFIG.API.BASE_URL, path);
@@ -20,6 +22,7 @@ export async function postJson(path, body, init = {}) {
     headers: {
       'Content-Type': 'application/json',
       ...(APP_REQUEST_TOKEN ? { 'x-app-token': APP_REQUEST_TOKEN } : {}),
+      ...(APP_VERSION ? { 'x-app-version': APP_VERSION } : {}),
       ...headers,
     },
     ...restInit,

--- a/tests/unit/app-auth.test.js
+++ b/tests/unit/app-auth.test.js
@@ -4,17 +4,25 @@ import { verifyAppRequest } from '../../api/lib/app-auth.js';
 
 const SAVED = process.env.APP_REQUEST_SECRET;
 
-function req(token) {
-  return { headers: token === undefined ? {} : { 'x-app-token': token } };
+const SAVED_MIN = process.env.APP_AUTH_MIN_VERSION;
+
+function req(token, version) {
+  const headers = {};
+  if (token !== undefined) headers['x-app-token'] = token;
+  if (version !== undefined) headers['x-app-version'] = version;
+  return { headers };
 }
 
 describe('verifyAppRequest', () => {
   beforeEach(() => {
     delete process.env.APP_REQUEST_SECRET;
+    delete process.env.APP_AUTH_MIN_VERSION;
   });
   afterEach(() => {
     if (SAVED !== undefined) process.env.APP_REQUEST_SECRET = SAVED;
     else delete process.env.APP_REQUEST_SECRET;
+    if (SAVED_MIN !== undefined) process.env.APP_AUTH_MIN_VERSION = SAVED_MIN;
+    else delete process.env.APP_AUTH_MIN_VERSION;
   });
 
   it('passes (disabled) when no secret is configured — backward compatible', () => {
@@ -43,5 +51,35 @@ describe('verifyAppRequest', () => {
   it('rejects a token of different length without throwing', () => {
     process.env.APP_REQUEST_SECRET = 's3cret-value';
     expect(verifyAppRequest(req('short')).ok).toBe(false);
+  });
+
+  describe('version gate (APP_AUTH_MIN_VERSION)', () => {
+    beforeEach(() => {
+      process.env.APP_REQUEST_SECRET = 's3cret-value';
+      process.env.APP_AUTH_MIN_VERSION = '1.2.0';
+    });
+
+    it('grace-passes an older released app (no token, lower version) — does not break shipped apps', () => {
+      const r = verifyAppRequest(req(undefined, '1.0.4'));
+      expect(r.ok).toBe(true);
+      expect(r.reason).toBe('grace-legacy-version');
+    });
+
+    it('grace-passes a client that sends no version header', () => {
+      expect(verifyAppRequest(req(undefined, undefined)).ok).toBe(true);
+    });
+
+    it('enforces the token for versions at or above the minimum', () => {
+      expect(verifyAppRequest(req(undefined, '1.2.0')).ok).toBe(false); // new version, no token
+      expect(verifyAppRequest(req('wrong', '1.3.0')).ok).toBe(false);
+      const ok = verifyAppRequest(req('s3cret-value', '1.2.0'));
+      expect(ok.ok).toBe(true);
+      expect(ok.reason).toBe('token');
+    });
+
+    it('without APP_AUTH_MIN_VERSION, enforces the token for all (strict)', () => {
+      delete process.env.APP_AUTH_MIN_VERSION;
+      expect(verifyAppRequest(req(undefined, '1.0.4')).ok).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
## 목적
엔드포인트 인증(`APP_REQUEST_SECRET`)을 **이미 출시된 앱(iOS 1.0.4 등)을 깨지 않고 즉시 켤 수 있게** 한다. (#32 후속)

서버에서 인증을 켜면 토큰을 안 보내는 구버전 앱이 403으로 OCR/주변검색이 막히는 문제를, **버전 게이트**로 해결.

## 동작
- 클라이언트가 `x-app-version`(빌드 버전) 전송.
- 서버 `APP_AUTH_MIN_VERSION` 미만(또는 버전 헤더 미상=구앱)은 **grace 통과**, 그 이상만 토큰 강제.
- `APP_AUTH_MIN_VERSION` 미설정 = strict(전체 토큰 강제) — 구버전 소멸 후 사용.

## 활성화 절차 (무중단)
1. 토큰 싣는 릴리스 버전 결정(예: 1.2.0) → 웹 재배포 + 네이티브 신규 출시.
2. Vercel env: `APP_REQUEST_SECRET`·`VITE_APP_REQUEST_SECRET`(동일값)·`APP_AUTH_MIN_VERSION=1.2.0`.
3. 1.2.0+ 강제, 구버전 grace. → 구버전 소멸 후 `APP_AUTH_MIN_VERSION` 제거 = 전체 strict.

## ⚠️ 정직한 한계
`x-app-version`은 위조 가능 → 이 게이트는 **보안 경계가 아니라 마이그레이션 장치**. grace 구간의 남용은 rate-limit(fail-closed) + cost-guard(전역 일일 상한)로 묶인다. 진짜 인증은 Phase 2(App Attest/Play Integrity).

## 변경
- `api/lib/app-auth.js`: 버전 게이트 + `compareVersions`.
- `src/lib/api-client.js`: 모든 POST에 `x-app-version` 첨부.
- `.env.example` / `docs/ENDPOINT_AUTH_PLAN.md`: env + 런북.
- tests: app-auth 9 (was 5). 전체 66 green, lint/build/secrets ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)