### PR TITLE
feat(api): Phase 2 attestation foundation (nonce infra + spec, verification stubbed)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,7 @@ APP_AUTH_MIN_VERSION=
 OCR_DAILY_MAX=0
 IDENTIFY_DAILY_MAX=0
 KAKAO_DAILY_MAX=0
+
+# Device attestation (Phase 2) — 기기 검증 강제 여부(기본 false). 검증 구현 완료 전엔 켜지 말 것.
+# 전체 설계/남은 작업: docs/PHASE2_ATTESTATION_SPEC.md
+ATTESTATION_REQUIRED=false

--- a/api/lib/attestation.js
+++ b/api/lib/attestation.js
@@ -1,0 +1,80 @@
+/**
+ * 기기 검증(Attestation) — Phase 2 서버 토대
+ *
+ * 목적: Apple App Attest / Google Play Integrity로 "정품 기기의 정품 앱"임을 암호학적으로
+ * 증명해, 공유 토큰(위조 가능)을 넘어서는 진짜 인증을 네이티브 경로에 제공한다.
+ *
+ * ⚠️ 현재 상태: 아래 **nonce(챌린지) 인프라는 구현·테스트 완료**, 그러나 실제
+ * attestation/assertion **검증은 미구현 stub**이다(네이티브 토큰 + Apple/Google 검증 필요).
+ * 전체 설계·남은 작업: docs/PHASE2_ATTESTATION_SPEC.md.
+ *
+ * 통합 지점(미연결): verifyAppRequest(api/lib/app-auth.js)가 토큰 검사보다 먼저 이 모듈의
+ * verify*를 우선 경로로 호출하도록 연결 예정. ATTESTATION_REQUIRED=true 일 때만 강제.
+ */
+
+import crypto from 'node:crypto';
+import { Redis } from '@upstash/redis';
+
+const CHALLENGE_PREFIX = 'cardai:attest:nonce:';
+const CHALLENGE_TTL_SECONDS = 300; // 5분
+
+function hasUpstashEnv() {
+  const url = process.env.UPSTASH_REDIS_REST_URL || process.env.KV_REST_API_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN || process.env.KV_REST_API_TOKEN;
+  return Boolean(url && token);
+}
+
+export function isAttestationEnforced() {
+  return process.env.ATTESTATION_REQUIRED === 'true';
+}
+
+/**
+ * 1회용 nonce(챌린지) 발급. 클라이언트는 이 nonce를 attest/assert 서명에 포함한다.
+ * 서버에 저장되어 재사용/위조를 막는다(replay 방지).
+ * @returns {Promise<{ nonce: string, ttl: number } | null>} Upstash 불가 시 null
+ */
+export async function createChallenge() {
+  if (!hasUpstashEnv()) return null;
+  const nonce = crypto.randomBytes(32).toString('base64url');
+  const redis = Redis.fromEnv();
+  await redis.set(`${CHALLENGE_PREFIX}${nonce}`, '1', { ex: CHALLENGE_TTL_SECONDS });
+  return { nonce, ttl: CHALLENGE_TTL_SECONDS };
+}
+
+/**
+ * nonce 1회용 소비(원자적 get-and-delete). 존재하고 처음 소비될 때만 true.
+ * 만료/재사용/위조 nonce는 false. 검증 인프라(Upstash)가 없으면 false(fail-closed).
+ * @param {string} nonce
+ * @returns {Promise<boolean>}
+ */
+export async function consumeChallenge(nonce) {
+  if (!nonce || typeof nonce !== 'string') return false;
+  if (!hasUpstashEnv()) return false;
+  const redis = Redis.fromEnv();
+  const value = await redis.getdel(`${CHALLENGE_PREFIX}${nonce}`);
+  return value !== null && value !== undefined;
+}
+
+/**
+ * Apple App Attest 검증 — 미구현(stub).
+ * 실제 구현: CBOR attestation 파싱 → Apple App Attest 루트 인증서 체인 검증 →
+ * nonce/RP ID 해시 확인 → 공개키+counter 저장. 이후 요청은 assertion(서명+counter) 검증.
+ * 참고: docs/PHASE2_ATTESTATION_SPEC.md
+ */
+export async function verifyAppleAttestation() {
+  throw new Error(
+    '[Attestation] Apple App Attest verification not implemented — see docs/PHASE2_ATTESTATION_SPEC.md'
+  );
+}
+
+/**
+ * Google Play Integrity 검증 — 미구현(stub).
+ * 실제 구현: 클라이언트 integrity token → Google Play Integrity API로 복호화/검증 →
+ * appRecognitionVerdict/deviceIntegrity + nonce 확인.
+ * 참고: docs/PHASE2_ATTESTATION_SPEC.md
+ */
+export async function verifyPlayIntegrity() {
+  throw new Error(
+    '[Attestation] Play Integrity verification not implemented — see docs/PHASE2_ATTESTATION_SPEC.md'
+  );
+}

--- a/docs/ENDPOINT_AUTH_PLAN.md
+++ b/docs/ENDPOINT_AUTH_PLAN.md
@@ -48,12 +48,15 @@
   3. 이 시점부터 1.2.0+ 요청은 인증 강제, 구버전(1.0.4 등)은 grace 통과(무중단).
   4. 구버전 사용량이 충분히 소멸하면 `APP_AUTH_MIN_VERSION` 제거 → 전체 strict.
 
-## Phase 2 — 기기 검증(진짜 인증)
-- **iOS**: Apple App Attest (DeviceCheck) — 앱이 정품 기기의 정품 앱임을 암호학적으로 증명.
-- **Android**: Google Play Integrity API.
+## Phase 2 — 기기 검증(진짜 인증) 🚧 착수
+- 서버 토대 착수: `api/lib/attestation.js`(nonce 챌린지 인프라 구현·테스트 + 검증 stub),
+  env `ATTESTATION_REQUIRED`(기본 false). **전체 스펙·남은 작업: `docs/PHASE2_ATTESTATION_SPEC.md`**.
+- **iOS**: Apple App Attest (DCAppAttestService), **Android**: Google Play Integrity API.
 - 클라이언트가 attestation 토큰을 받아 전송 → 서버가 Apple/Google로 검증 →
   `verifyAppRequest`가 이 검증을 우선 경로로 사용(공유 토큰은 웹 폴백/회전 보조로 잔존).
 - 웹 PWA는 attestation 불가 → 웹 트래픽은 Phase 1 토큰 + 레이트리밋 + 비용캡으로 계속 방어.
+- 남은 핵심: 네이티브 Capacitor 플러그인(Swift/Kotlin) + Apple/Google 토큰 검증 + 키 저장소
+  + 엔드포인트 + `verifyAppRequest` 연결 + 콘솔 설정(이 환경에서 빌드/실기기 불가 → 핸드오프).
 
 ## 결정 필요
 - Phase 1 토큰을 **즉시 활성화**할지(= Vercel/빌드에 시크릿 주입). 활성화 전까지는 no-op이라

--- a/docs/PHASE2_ATTESTATION_SPEC.md
+++ b/docs/PHASE2_ATTESTATION_SPEC.md
@@ -1,0 +1,84 @@
+# Phase 2 — 기기 검증(Device Attestation) 구현 스펙
+
+공유 토큰(Phase 1, 위조 가능)을 넘어, **정품 기기의 정품 앱**임을 암호학적으로 증명하는 진짜 인증.
+네이티브(iOS/Android) 경로에 적용하며, 웹 PWA는 attestation 불가 → Phase 1 토큰 + rate-limit + cost-guard 유지.
+
+## 0. 현재 진행 상태 (이 PR)
+- ✅ `api/lib/attestation.js`: **nonce(챌린지) 인프라 구현·테스트 완료** — `createChallenge`/`consumeChallenge`(1회용, Upstash GETDEL 원자 소비, 5분 TTL), `isAttestationEnforced()`(env 플래그).
+- ✅ 검증 **계약(인터페이스)** 정의 — `verifyAppleAttestation`/`verifyPlayIntegrity`는 **stub(throw)**. 가짜 "verified" 절대 반환 안 함.
+- ⛔ **미구현(이 환경에서 불가)**: 네이티브 Capacitor 플러그인(Swift/Kotlin), Apple/Google 토큰 검증, 키 저장소, `verifyAppRequest` 연결, Apple/Google 콘솔 설정.
+
+## 1. 위협 모델 / 적용 범위
+- 막으려는 것: 비브라우저(curl/스크립트) 및 변조 앱이 Vision/Kakao 프록시를 무료로 악용.
+- attestation은 **네이티브 앱** 트래픽에만 가능. 웹 PWA는 불가 → 웹은 Phase 1 토큰 + rate-limit(fail-closed) + cost-guard(전역 일일 상한)로 계속 방어.
+
+## 2. 플로우 개요
+```
+[첫 실행 — 키 등록(attest)]
+ client → GET /api/attest/challenge            (서버: createChallenge → nonce)
+ client → 플랫폼 attest(nonce) 생성            (iOS: DCAppAttestService.attestKey / Android: Play Integrity)
+ client → POST /api/attest/register {attestation, keyId, platform, nonce}
+ server → consumeChallenge(nonce) + 플랫폼 검증 → 공개키/검증결과 저장 → attestation 세션 토큰 발급(짧은 TTL)
+
+[이후 요청 — 매 호출 assert]
+ client → 호출마다 assertion/integrity 토큰 동봉(또는 단기 attestation 세션 토큰)
+ server(verifyAppRequest) → 검증 통과해야 비용 엔드포인트 진입
+```
+
+## 3. iOS — Apple App Attest (DCAppAttestService)
+- 전제: Apple Developer에서 App ID에 **App Attest capability** 활성화. 시뮬레이터 미지원(실기기 필요).
+- 네이티브:
+  - `DCAppAttestService.shared.isSupported` 확인
+  - `generateKey()` → keyId (Keychain 보관)
+  - `attestKey(keyId, clientDataHash = SHA256(nonce))` → attestation(CBOR)
+  - 이후 요청: `generateAssertion(keyId, clientDataHash = SHA256(nonce ‖ requestBody))` → assertion
+- 서버 검증(register):
+  1. CBOR attestation 파싱 → x5c 인증서 체인 → **Apple App Attest Root CA** 로 검증
+  2. nonce(authData의 RP ID hash + clientDataHash) 확인, aaguid 확인(prod=appattest)
+  3. credId, **공개키, signCount=0** 저장(기기별)
+- 서버 검증(assert): 저장 공개키로 서명 검증 + **signCount 단조 증가** 확인(replay 방지) + nonce 소비.
+- 참고: Apple "Validating Apps That Connect to Your Server". node 라이브러리 후보: `node-app-attest`, `@peculiar/*`(CBOR/x509).
+
+## 4. Android — Play Integrity API
+- 전제: Google Play Console에서 Play Integrity 활성화 + Google Cloud 프로젝트/서비스계정.
+- 네이티브: `IntegrityManager.requestIntegrityToken(nonce)` → integrity token.
+- 서버 검증: Play Integrity API(`decodeIntegrityToken`)로 복호화/검증 →
+  `appRecognitionVerdict == PLAY_RECOGNIZED`, `deviceIntegrity` 만족, `requestDetails.nonce == 발급 nonce`, `packageName == com.sterlingstarai.cardai` 확인.
+- 토큰은 단기. assert 단계는 요청별 integrity token 또는 단기 세션 토큰.
+
+## 5. 서버 컴포넌트 (TODO)
+- `GET /api/attest/challenge` — `createChallenge()` 래퍼. CORS + rate-limit + Phase1 app-auth 적용. (lib는 준비됨; 엔드포인트만 추가)
+- `POST /api/attest/register` — 플랫폼별 `verifyAppleAttestation`/`verifyPlayIntegrity` 호출 → 기기 공개키/검증결과 저장 → 단기 attestation 세션 토큰 발급.
+- **키/세션 저장소**: 기기별 {keyId, publicKey, signCount} + 세션 토큰. Upstash(또는 정식 DB). signCount 갱신은 CAS/원자 연산으로(동시 assert replay 방지).
+- `verifyAppRequest` 연결: 우선순위 = attestation 세션/assertion → (실패+grace 아님) → Phase1 토큰. `ATTESTATION_REQUIRED=true`이고 플랫폼이 네이티브일 때만 강제. 웹은 토큰 경로.
+
+## 6. Capacitor 플러그인
+- 유지되는 공식 플러그인 부재 가능성 → **커스텀 플러그인** 작성 또는 커뮤니티 검토.
+  - iOS: Swift로 DCAppAttestService 브리지.
+  - Android: Kotlin으로 Play Integrity 브리지.
+- 클라이언트 흐름: 첫 실행 register → 토큰을 `api-client`가 헤더로 첨부(`x-attestation`).
+
+## 7. 설정 전제(콘솔)
+- Apple Developer: App ID App Attest capability, 프로덕션 환경 설정.
+- Google: Play Integrity API 사용 설정, Cloud 프로젝트 + 서비스계정 키(서버 env).
+- Vercel env: `ATTESTATION_REQUIRED`(기본 false), 서비스계정/Apple 검증용 키, 저장소 연결.
+
+## 8. 롤아웃 (무중단)
+- Phase 1 버전 게이트와 동일 전략: attestation을 싣는 릴리스부터 `x-app-version >= N`에 한해 강제.
+- 단계: (1) attestation 지원 앱 출시 → (2) 서버 검증 가동 + `ATTESTATION_REQUIRED=true`(신버전만) → (3) 구버전 소멸 후 전체 강제.
+- 웹은 전 구간 Phase 1 토큰 경로 유지.
+
+## 9. 정직한 한계
+- 웹 PWA는 attestation 불가 — 웹 트래픽의 봇/abuse는 attestation으로 못 막는다. 웹은 토큰+rate-limit+cost-guard가 한계선.
+- attestation도 만능 아님(루팅/탈옥/MITM 일부 우회 가능) — 비용 상한(cost-guard)은 항상 병행 유지.
+
+## 10. 남은 작업 체크리스트
+- [ ] Capacitor App Attest 플러그인(iOS Swift)
+- [ ] Capacitor Play Integrity 플러그인(Android Kotlin)
+- [ ] `verifyAppleAttestation` 실제 구현(CBOR/x509/cert chain/nonce/signCount)
+- [ ] `verifyPlayIntegrity` 실제 구현(Google API decode/verify)
+- [ ] 기기 키·세션 저장소(Upstash/DB) + signCount CAS
+- [ ] `/api/attest/challenge`·`/api/attest/register` 엔드포인트
+- [ ] `verifyAppRequest` 연결(우선순위 + ATTESTATION_REQUIRED + 플랫폼 구분)
+- [ ] Apple/Google 콘솔 설정 + Vercel env
+- [ ] 실기기 E2E(시뮬레이터/에뮬레이터 attestation 제약 주의)

--- a/tests/unit/attestation.test.js
+++ b/tests/unit/attestation.test.js
@@ -1,0 +1,84 @@
+/** @vitest-environment node */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const setMock = vi.fn(async () => 'OK');
+let getdelReturn = '1';
+const getdelMock = vi.fn(async () => getdelReturn);
+
+vi.mock('@upstash/redis', () => ({
+  Redis: { fromEnv: () => ({ set: setMock, getdel: getdelMock }) },
+}));
+
+const { createChallenge, consumeChallenge, verifyAppleAttestation, verifyPlayIntegrity, isAttestationEnforced } =
+  await import('../../api/lib/attestation.js');
+
+const saved = {
+  url: process.env.UPSTASH_REDIS_REST_URL,
+  token: process.env.UPSTASH_REDIS_REST_TOKEN,
+  enforced: process.env.ATTESTATION_REQUIRED,
+};
+
+describe('attestation nonce infrastructure', () => {
+  beforeEach(() => {
+    setMock.mockClear();
+    getdelMock.mockClear();
+    getdelReturn = '1';
+    process.env.UPSTASH_REDIS_REST_URL = 'https://example.upstash.io';
+    process.env.UPSTASH_REDIS_REST_TOKEN = 'tok';
+    delete process.env.ATTESTATION_REQUIRED;
+  });
+
+  afterEach(() => {
+    if (saved.url !== undefined) process.env.UPSTASH_REDIS_REST_URL = saved.url;
+    else delete process.env.UPSTASH_REDIS_REST_URL;
+    if (saved.token !== undefined) process.env.UPSTASH_REDIS_REST_TOKEN = saved.token;
+    else delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    if (saved.enforced !== undefined) process.env.ATTESTATION_REQUIRED = saved.enforced;
+    else delete process.env.ATTESTATION_REQUIRED;
+  });
+
+  it('issues a unique nonce with TTL and stores it', async () => {
+    const a = await createChallenge();
+    const b = await createChallenge();
+    expect(a.nonce).toBeTruthy();
+    expect(a.ttl).toBe(300);
+    expect(a.nonce).not.toBe(b.nonce);
+    expect(setMock).toHaveBeenCalledWith(expect.stringContaining('cardai:attest:nonce:'), '1', { ex: 300 });
+  });
+
+  it('returns null when Upstash is unavailable (cannot issue challenges)', async () => {
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    expect(await createChallenge()).toBeNull();
+    expect(setMock).not.toHaveBeenCalled();
+  });
+
+  it('consumes a valid nonce exactly once (getdel returns the value)', async () => {
+    getdelReturn = '1';
+    expect(await consumeChallenge('abc')).toBe(true);
+    expect(getdelMock).toHaveBeenCalledWith('cardai:attest:nonce:abc');
+  });
+
+  it('rejects an unknown/expired/replayed nonce (getdel returns null)', async () => {
+    getdelReturn = null;
+    expect(await consumeChallenge('gone')).toBe(false);
+  });
+
+  it('rejects empty input and fails closed without Upstash', async () => {
+    expect(await consumeChallenge('')).toBe(false);
+    delete process.env.UPSTASH_REDIS_REST_URL;
+    delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    expect(await consumeChallenge('abc')).toBe(false);
+  });
+
+  it('verification stubs throw (not yet implemented) — no false "verified"', async () => {
+    await expect(verifyAppleAttestation()).rejects.toThrow(/not implemented/);
+    await expect(verifyPlayIntegrity()).rejects.toThrow(/not implemented/);
+  });
+
+  it('isAttestationEnforced reflects the env flag (default off)', () => {
+    expect(isAttestationEnforced()).toBe(false);
+    process.env.ATTESTATION_REQUIRED = 'true';
+    expect(isAttestationEnforced()).toBe(true);
+  });
+});


### PR DESCRIPTION
## 목적
기기 검증(Apple App Attest / Google Play Integrity)의 **서버측 토대 + 완전한 구현 스펙**을 착수. 가짜 검증(security theater) 없이 진짜 진행분만 포함. (#33 후속, Phase 2)

## 이 PR에 포함 (구현·테스트됨)
- `api/lib/attestation.js` — **nonce/챌린지 인프라**: `createChallenge`/`consumeChallenge`(Upstash GETDEL 원자적 1회용 소비, 5분 TTL, Upstash 없으면 fail-closed), `isAttestationEnforced()`(`ATTESTATION_REQUIRED`, 기본 off).
- 검증 **계약**: `verifyAppleAttestation`/`verifyPlayIntegrity`는 **명시적 미구현 stub(throw)** — 가짜 'verified' 절대 없음.
- `docs/PHASE2_ATTESTATION_SPEC.md` — 전체 설계(App Attest/Play Integrity 플로우, 서버 컴포넌트, Capacitor 플러그인, 콘솔 전제, 무중단 롤아웃, 정직한 한계, 남은작업 체크리스트).
- `.env.example` `ATTESTATION_REQUIRED`. 테스트 7 (attestation), 전체 **73 green**.

## 이 PR에 없음 (이 환경서 빌드/실기기 불가 → 핸드오프, 스펙에 명시)
- Capacitor 네이티브 플러그인(iOS Swift App Attest / Android Kotlin Play Integrity)
- Apple/Google 토큰 실제 검증, 기기 키 저장소, `/api/attest/*` 엔드포인트
- `verifyAppRequest` 연결, Apple/Google 콘솔 설정

## 안전성
- 모두 inert: `ATTESTATION_REQUIRED` 기본 false, 검증 미연결 → 기존 동작 무중단.
- 웹 PWA는 attestation 불가 → 웹은 Phase 1 토큰 + rate-limit + cost-guard로 계속 방어(스펙 §9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)